### PR TITLE
Fix build  dependencies 

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools>=41.0.0
+        pip install -r requirements.txt
         pip install -e .
     - name: Lint with flake8
       run: |
@@ -31,5 +32,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pip install pytest
         pytest

--- a/dp/ensemble.py
+++ b/dp/ensemble.py
@@ -166,7 +166,7 @@ class PrivateClassifier(BaseEnsemble, ClassifierMixin):
         )
         X = check_array(X)
         self.teacher_preds_, y_pred = _aggregate_teachers(
-            X, self.estimators_, self.epsilon, self.random_state
+            X, self.estimators_, self.epsilon, 'laplace', self.random_state
         )
         return y_pred
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
-REQUIRED_PKGS = ['scikit-learn==0.22.1']
-TESTS_REQUIRE = ['pytest==5.2.2']
+REQUIRED_PKGS = ['scikit-learn==0.24.1']
+TESTS_REQUIRE = ['pytest==6.2.4']
 
 setup(
     name='tinydp',


### PR DESCRIPTION
This PR fixes a missmatch between setup.py and requirements.txt deps, that resulted in an unsupported version of sklearn to be installed. 

A missing parameter in `_aggregate_teachers` calls has been fixed.